### PR TITLE
use `Error` for reject

### DIFF
--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -39,7 +39,7 @@ module.exports = {
             }
 
             if(!countryRules){
-                return reject('Unsupported county code "' + countryCode + '". Supported codes are "AU" (Australia) and "US" (United States)');
+                return reject(new Error('Unsupported county code "' + countryCode + '". Supported codes are "AU" (Australia) and "US" (United States)'));
             }
 
             async.map(countryRules.getRules(), function(rule, cb){

--- a/test/extractor.spec.js
+++ b/test/extractor.spec.js
@@ -1,0 +1,19 @@
+var assert = require('assert')
+  , _ = require('lodash')
+  , extractor = require('../lib/extractor')
+  , mockData = require('./mockData/au');
+
+describe('Extractor', function () {
+  it('throws an error when arguments are incorrect', function (done) {
+    extractor.getCandidates(
+      mockData.realText1
+    )
+
+    .then(done)
+
+    .catch(function (e) {
+      assert(_.isError(e), 'Result should be an Error type');
+      done();
+    })
+  })
+})


### PR DESCRIPTION
uses `Error` type for `reject` call, to prevent browser warning messages.  Also adds a test for this

fixes #4 